### PR TITLE
Implemented Standardizing for the names for --> regular faculty 

### DIFF
--- a/admin/resolve_discrepancies.py
+++ b/admin/resolve_discrepancies.py
@@ -1,0 +1,132 @@
+from src.data.db_manager import DatabaseManager
+
+class NameStandardizer:
+    def __init__(self, faculty_list_path: str):
+        """
+        Initialize the NameStandardizer with the faculty list.
+
+        Args:
+            faculty_list_path: Path to the faculty list file.
+        """
+        self.faculty_list = self._load_faculty_names(faculty_list_path)
+        self.db = DatabaseManager()
+
+    def _load_faculty_names(self, file_path):
+        """Load faculty names from the provided text file."""
+        with open(file_path, 'r', encoding='utf-8') as file:
+            lines = file.readlines()
+
+        faculty_names = []
+        for line in lines:
+            if line.strip() and ':' not in line:  # Exclude empty lines and department headers
+                faculty_names.append(line.strip())
+
+        return sorted(faculty_names)
+
+    def standardize_faculty_name(self, faculty_name):
+        """Standardizes faculty names from the faculty list into (first, middle_init, last)."""
+        parts = faculty_name.split()
+
+        if len(parts) == 1:  # Only last name
+            return None, None, parts[0]
+        elif len(parts) == 2:  # First and last name
+            return parts[0], None, parts[1]
+        else:  # First, middle, last
+            return parts[0], " ".join(parts[1:-1]), parts[-1]
+
+    def standardize_instructor_name(self, instructor_name):
+        """Standardizes instructor names from the database into (first, middle_init, last)."""
+        if "," not in instructor_name:
+            return None, None, instructor_name.strip()
+
+        last_name, rest = instructor_name.split(",", 1)
+        last_name = last_name.strip()
+
+        rest_of_names = rest.strip().split()
+        first_name = rest_of_names[0]
+
+        middle_init = None
+        if len(rest_of_names) > 1 and '.' in rest_of_names[1]:  # Detect middle initial
+            middle_init = rest_of_names[1]
+
+        return first_name, middle_init, last_name
+
+    def is_regular_faculty(self, instructor_name):
+        """
+        Check if an instructor is in the faculty list.
+
+        Args:
+            instructor_name: Name in "Last, First Middle" format from the database.
+
+        Returns:
+            Boolean - True if instructor is found in the faculty list, otherwise False.
+        """
+        standardized_instructor = self.format_name_tuple(self.standardize_instructor_name(instructor_name))
+
+        for faculty in self.faculty_list:
+            standardized_faculty = self.format_name_tuple(self.standardize_faculty_name(faculty))
+            if self.compare_names(standardized_instructor, standardized_faculty):
+                return True  # Found in faculty list
+
+        return False  # Not in faculty list
+
+    def format_name_tuple(self, name_tuple):
+        """Convert name tuple into a standardized format."""
+        if name_tuple == (None, None, None):
+            return None  # Ignore names that couldn't be processed
+
+        first, middle, last = name_tuple
+        return (first or "", middle or "", last or "")  # Ensures comparison works
+
+    def compare_names(self, name1, name2):
+        """
+        Compare names while handling middle initials intelligently.
+
+        Returns:
+            True if names match based on first, last, and middle initials (if both have one).
+        """
+        if not name1 or not name2:
+            return False
+
+        # If either name has no middle initial, ignore middle initials
+        if not name1[1] or not name2[1]:
+            return (name1[0], name1[2]) == (name2[0], name2[2])  # Compare first & last names only
+
+        return name1 == name2  # Compare first, middle, and last names
+
+    def update_db_instructors(self):
+        """Standardize instructor names and update faculty status in the database."""
+
+        db_names = self.db.grade_distributions.distinct("instructor_name")
+
+        for old_name in db_names:
+            standardized_tuple = self.standardize_instructor_name(old_name)  
+            new_name = " ".join(filter(None, standardized_tuple))  # Convert tuple to string
+            
+            is_faculty = self.is_regular_faculty(old_name)  # Check faculty status
+
+            # Rename instructor to match standardized format
+            self.db.grade_distributions.update_many(
+                {'instructor_name': old_name},
+                {'$set': {'instructor_name': new_name}}
+            )
+
+            # Update faculty status after renaming
+            self.db.grade_distributions.update_many(
+                {'instructor_name': new_name},
+                {'$set': {'is_regular_faculty': is_faculty}}
+            )
+
+            print(f"Updated {old_name} to {new_name}: is_regular_faculty={is_faculty}")
+
+        print("Database update complete.")
+
+    
+    def untuple(self,name_tuple):
+        """Converts a tuple of names into a string."""
+        return " ".join(filter(None, name_tuple))
+
+# Example usage
+if __name__ == "__main__":
+    standardizer = NameStandardizer("faculty_list.txt")
+    standardizer.update_db_instructors()

--- a/admin/scrape_faculty.py
+++ b/admin/scrape_faculty.py
@@ -30,6 +30,7 @@ class WebScraper:
             url (str): The URL of the webpage to fetch.
             retries (int, optional): The number of times to retry fetching the webpage in case of failure. Defaults to 3.
             delay (int, optional): The delay in seconds between retries. Defaults to 60.
+            Added 60 seconds to the delay each retry.
 
         Returns:
             BeautifulSoup: A BeautifulSoup object containing the parsed HTML content of the webpage if the request is successful.
@@ -50,6 +51,7 @@ class WebScraper:
                 if i < retries - 1:
                     print(f"Retrying in {delay} seconds...")
                     time.sleep(delay)
+                    delay += 60
                 else:
                     print("Max retries exceeded.")
                     return None
@@ -105,7 +107,7 @@ def main():
                 print(f"Failed to fetch content for {department}")
                 break  # Stop the loop if a request fails
 
-        with open('faculty_list.txt', 'w') as file:
+        with open('faculty_list.txt', 'w', encoding='utf-8') as file:
             for dep, faculty in fac_list.items():
                 file.write(f"{dep}:\n")
                 for fac in faculty:

--- a/admin/update_db.py
+++ b/admin/update_db.py
@@ -63,10 +63,12 @@ class DatabaseUpdater:
             is_regular: Boolean indicating if instructor is regular faculty
                       (defaults to True)
         """
-        self.db.instructors.update_one(
-            {'name': instructor_name},
-            {'$set': {'is_regular_faculty': is_regular}}
+        self.db.grade_distributions.update_many(
+            {'instructor_name': instructor_name},   # Match existing instructor names
+            {'$set': {'is_regular_faculty': is_regular}},   # Add/Update the field
+            upsert=False   # Do NOT create new entries, just update existing ones
         )
+
 
     def match_instructor_names(self, grade_data_names, faculty_names):
         """

--- a/faculty_list.txt
+++ b/faculty_list.txt
@@ -1,6 +1,6 @@
 African Studies:
 Yvonne A. Braun
-André Djiffack
+AndrÃ© Djiffack
 Jenifer P. Craig
 John Fenn
 Stephen R. Frost
@@ -25,7 +25,7 @@ Lamia Karim
 Gyoung-Ah Lee
 Sandra L. Morgen
 Madonna L. Moss
-Theresa D. O’Nell
+Theresa D. Oâ€™Nell
 Philip W. Scher
 Carol T. Silverman
 J. Josh Snodgrass
@@ -48,7 +48,7 @@ Pamela E. Endzweig
 Dennis L. Jenkins
 Brian Klopotek
 Patricia Krier
-Brian L. O’Neill
+Brian L. Oâ€™Neill
 
 Asian Studies:
 Ina Asim
@@ -113,7 +113,7 @@ Shawn R. Lockery
 V. Patteson Lombardi
 Svetlana Maslakova
 Cristopher M. Neill
-Peter M. O’Day
+Peter M. Oâ€™Day
 Patrick C. Phillips
 John H. Postlethwait
 William Roberts
@@ -279,10 +279,10 @@ James R. Crosswhite
 Dianne M. Dugaw
 Cecilia Enjuto Rangel
 Maram Epstein
-Pedro García-Caro
+Pedro GarcÃ­a-Caro
 Evlyn Gould
 D. Gantt Gurley
-Michael Hames-García
+Michael Hames-GarcÃ­a
 Kathleen Rowe Karlyn
 Linda Kintz
 Martin Klebes
@@ -389,7 +389,7 @@ Anne van den Nouweland
 Glen R. Waddell
 Caroline E. Weber
 Wesley W. Wilson
-Cathleen S. Leué
+Cathleen S. LeuÃ©
 Robert Campbell
 Henry N. Goldstein
 Jo Anna Gray
@@ -424,7 +424,7 @@ C. Anne Laskaya
 Stephanie LeMenager
 David Leiwei Li
 Quinn Miller
-Kathleen O’Fallon
+Kathleen Oâ€™Fallon
 Priscilla P. Ovalle
 Paul W. Peppis
 Forest Pyle
@@ -467,7 +467,7 @@ Louise Westling
 George Wickes
 Louise M. Bishop
 David A. Frank
-Michael Hames-García
+Michael Hames-GarcÃ­a
 Lee Rumbarger
 
 Environmental Studies:
@@ -605,10 +605,10 @@ Yizhao Yang
 Ethnic Studies:
 Charise L. Cheney
 Lynn H. Fujiwara
-Michael Hames-García
+Michael Hames-GarcÃ­a
 Daniel HoSang
 Brian Klopotek
-Ernesto J. Martínez
+Ernesto J. MartÃ­nez
 Irmary Reyes-Santos
 Edward Olivos
 Jeffrey Ostler
@@ -905,7 +905,7 @@ Shaul E. Cohen
 Frederick Colby
 Jane K. Cramer
 Robert L. Davis
-André Djiffack
+AndrÃ© Djiffack
 Christopher J. Ellis
 Maram Epstein
 John B. Foster
@@ -990,10 +990,10 @@ Mark Carey
 Cecilia Enjuto Rangel
 Juan A. Epple
 Linda O. Fuller
-Leonardo García-Pabón
+Leonardo GarcÃ­a-PabÃ³n
 Spike Gildea
 Amalia Gladhart
-Michael Hames-García
+Michael Hames-GarcÃ­a
 James Harper
 Robert S. Haskett
 Derrick Hindery
@@ -1029,7 +1029,7 @@ Doris L. Payne
 Eric W. Pederson
 Melissa Redford
 Cynthia M. Vakareliyska
-T. Givón
+T. GivÃ³n
 Russell S. Tomlin
 Gregory D. Anderson
 Dare A. Baldwin
@@ -1171,7 +1171,7 @@ Judith S. Eisen
 Clifford Kentros
 Charles B. Kimmel
 Shawn R. Lockery
-Peter M. O’Day
+Peter M. Oâ€™Day
 Cristopher Neill
 John H. Postlethwait
 William Roberts
@@ -1377,20 +1377,20 @@ Simone Da Silva
 Robert L. Davis
 Laurie deGonzalez
 Juanita Devereaux
-André Djiffack
+AndrÃ© Djiffack
 Paula Ellister
 Cecilia Enjuto Rangel
 Hilary Fisher
-Pedro García-Caro
-Leonardo García-Pabón
+Pedro GarcÃ­a-Caro
+Leonardo GarcÃ­a-PabÃ³n
 Amalia Gladhart
 Evlyn Gould
 Gina Herrmann
 Nathalie Hester
 Claudia Holguin
 Harinder Kaur Khalsa
-Mónica Lara
-Kelley León Howarth
+MÃ³nica Lara
+Kelley LeÃ³n Howarth
 Massimo Lollini
 Karen McPherson
 Shelley Merello
@@ -1409,7 +1409,7 @@ Melanie Williams
 Gloria Zabala
 Alex Zunterstein
 Randi M. Brox
-Françoise G. Calin
+FranÃ§oise G. Calin
 David J. Curland
 Richard H. Desroches
 Juan A. Epple
@@ -1513,7 +1513,7 @@ Women's and Gender Studies:
 Oluwakemi Balogun
 Yvonne A. Braun
 Lynn H. Fujiwara
-Ernesto J. Martínez
+Ernesto J. MartÃ­nez
 Judith Raiskin
 Elizabeth Reis
 Ellen K. Scott


### PR DESCRIPTION
I implemented standardized naming for instructors using the format of First, Middle Initial, Last Name to ensure consistency when comparing scraped faculty data with the database. This change simplifies faculty status verification and improves accuracy when distinguishing between All Instructors and Regular Faculty as required in the assignment. 

Also I added more delay to the scraper to ensure it works FOR SURE, because one of the many times I tested the scraper it didn't work. So more delay.